### PR TITLE
Added support for mjs file format.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -188,7 +188,7 @@ function gzipPlugin(options: GzipPluginOptions = {}): Plugin {
 
                     // file name filter option check
 
-                    const fileNameFilter = options.filter || /\.(js|json|css)$/
+                    const fileNameFilter = options.filter || /\.(js|mjs|json|css)$/
 
                     if (
                         isRegExp(fileNameFilter) &&


### PR DESCRIPTION
Most of the example about loading js with es modules uses .mjs file format.
ex [click here](https://developers.google.com/web/fundamentals/primers/modules).