### PR TITLE
gzipPlugin: compress html files by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ rollup({
 
 Control which of the output files to compress.
 
-Defaults to `/\.(js|mjs|json|css)$/`
+Defaults to `/\.(js|mjs|json|css|html)$/`
 
 **gzipOptions** `object`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ export interface GzipPluginOptions {
     /**
      * Control which of the output files to compress
      *
-     * Defaults to `/\.(js|json|css)$/`
+     * Defaults to `/\.(js|json|css|html)$/`
      */
     filter?: RegExp | ((fileName: string) => boolean)
 
@@ -185,7 +185,7 @@ function gzipPlugin(options: GzipPluginOptions = {}): Plugin {
                         // file name filter option check
 
                         const fileNameFilter =
-                            options.filter || /\.(js|mjs|json|css)$/
+                            options.filter || /\.(js|mjs|json|css|html)$/
 
                         if (
                             isRegExp(fileNameFilter) &&


### PR DESCRIPTION
[@rollup/plugin-html](https://github.com/rollup/plugins/tree/master/packages/html) creates index.html as asset.  It is reasonable when rollup-plugin-gz compresses also the html files by default, apart from .css and .js files.