### PR TITLE
feat(filter): added svg files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -162,7 +162,7 @@ function gzipPlugin(explicitOptions: GzipPluginOptions = {}): Plugin {
 
   const options: Required<GzipPluginOptions> = {
     // default options
-    filter: /\.(js|mjs|cjs|json|css|html|wasm)$/,
+    filter: /\.(js|mjs|cjs|json|css|html|wasm|svg)$/,
     fileName: '.gz',
     customCompression: (fileContent: string | Buffer) =>
       gzipPromise(fileContent, options.gzipOptions),


### PR DESCRIPTION
hello :)

just found your plugin (thanks it's awesome !) and i thought "well i'd like to have the svg files in the filter by default" so here we are :)

(didn't add a test, didn't really know where to put, let me know !)