### PR TITLE
Make rollup an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,5 +63,10 @@
   "peerDependencies": {
     "rollup": ">=2.0.0"
   },
+  "peerDependenciesMeta": {
+    "rollup": {
+      "optional": true
+    }
+  },
   "packageManager": "yarn@4.12.0"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,11 @@ import { basename, dirname, join } from 'path'
 import { promisify } from 'util'
 import { gzip, ZlibOptions } from 'zlib'
 
-import {
+import type {
   OutputAsset,
   OutputChunk,
   OutputOptions,
   Plugin,
-  VERSION,
 } from 'rollup'
 
 const readFile = promisify(fs.readFile)
@@ -128,14 +127,19 @@ function getOutputFileContent(
 
 // actual plugin code
 
-function performInitChecks(options: GzipPluginOptions) {
-  if (VERSION < '2.0.0') {
-    console.error(
-      '[rollup-plugin-gzip] This plugin supports rollup version >= 2.0.0!',
-    )
-    console.error(
-      'For older rollup versions, please use an older version of this plugin.',
-    )
+async function performInitChecks(options: GzipPluginOptions) {
+  try {
+    const { VERSION } = await import('rollup')
+    if (VERSION < '2.0.0') {
+      console.error(
+        '[rollup-plugin-gzip] This plugin supports rollup version >= 2.0.0!',
+      )
+      console.error(
+        'For older rollup versions, please use an older version of this plugin.',
+      )
+    }
+  } catch {
+    // rollup not available (e.g. using rolldown) — skip version check
   }
 
   // check for old options


### PR DESCRIPTION
This allows the plugin to be used with rolldown without requiring rollup to be installed. The rollup import is now type-only (erased at runtime), and the version check uses a dynamic import that gracefully skips if rollup is unavailable.